### PR TITLE
Add NWBInspector to the upload documentation

### DIFF
--- a/docs/10_using_dandi.md
+++ b/docs/10_using_dandi.md
@@ -113,10 +113,21 @@ two different servers differ slightly.
       After you provide name and description, the dataset identifer will be created, 
       we will call this `<dataset_id>`.
     1. NWB format:
-        1. Convert your data to NWB 2.1+ in a local folder. Let's call this `<source_folder>`
+        1. Convert your data to NWB 2.1+ in a local folder. Let's call this `<source_folder>`.
         This step can be complex depending on your data. Feel free to [reach out to
         us for help](https://github.com/dandi/helpdesk/discussions).
-        1. Validate the NWB files by running: `dandi validate <source_folder>`. 
+        1. Check your files for [NWB Best Practices](https://nwbinspector.readthedocs.io/en/dev/best_practices/best_practices_index.html) by installing
+        the [NWBInspector](https://nwbinspector.readthedocs.io/en/dev/user_guide/user_guide.html) (`pip install -U nwbinspector`) and running
+
+                nwbinspector <source_folder>
+                
+        1. Thoroughly read through the NWBInspector report and try to address as many issues as possible. 
+        Some autodetected violations, such as `check_data_orientation`, may be safely ignored in the event that the data is indeed confirmed to be in the correct form. 
+        If the report is too large to efficiently navigate in your console, a report can be saved using
+
+                nwbinspector <source_folder> --report-save-path <report_location>.txt
+        
+        1. Once your files are confirmed to ahere to the Best Practices, perform an official validation of the NWB files by running: `dandi validate <source_folder>`. 
         **If you are having trouble with validation, make sure the conversions were run with the most recent version of `PyNWB` and `MatNWB`.**
         1. Preparing a dataset folder for upload:
 


### PR DESCRIPTION
Hello everyone!

With the [NWBInspector project](https://github.com/neurodatawithoutborders/nwbinspector) converging on a final stable API, we're looking to start encouraging more widespread usage prior even to the early stages of DANDI validation. While these steps are technically optional right now, and `dandi validation` should catch any missing required metadata, we hope this should help improve the overall quality of NWBFiles that are ultimately uploaded.

Listing this in draft for the moment while we finalize a couple things on our side with regards to documentations and documentation links.