### PR TITLE
ENH: move staging server specification into the text

### DIFF
--- a/docs/10_using_dandi.md
+++ b/docs/10_using_dandi.md
@@ -138,7 +138,10 @@ two different servers differ slightly.
                 cd <dataset_id>
                 dandi organize <source_folder> -f dry
                 dandi organize <source_folder>
-                dandi upload  # for staging: dandi upload -i dandi-staging
+                dandi upload
+
+            For upload to staging server, specify that explicitly via `-i` option, e.g.
+            `dandi upload -i dandi-staging`.
 
         1. Add metadata by visiting your dandiset landing page: 
        `https://dandiarchive.org/dandiset/<dataset_id>/draft` and clicking on the `METADATA` link.


### PR DESCRIPTION
Apparently Windows users might not be aware of  "# the rest is a comment"
which could bring confusion and cut-pasting the entire line and thus
trailing -i also into command prompt, but magically omitting the "odd" #.
As a result they would be trying to upload to staging although originally
intending for uploading to the main instance.

Placing such text on a separate line should remove such ambiguity