### PR TITLE
Edit new subsections of Using DANDI

### DIFF
--- a/docs/11_view.md
+++ b/docs/11_view.md
@@ -4,7 +4,7 @@
 
 When you go to the [DANDI Web application](https://dandiarchive.org/), you can click
 on `PUBLIC DANDISET` to access all `Dandisets` currently available 
-in the archive, and you can sort them by name, identifier, or date of modification.
+in the archive, and you can sort them by name, identifier, size, or date of modification.
 
 <img
 src="../img/web_browse.png"

--- a/docs/11_view.md
+++ b/docs/11_view.md
@@ -1,18 +1,18 @@
-# View Dandisets
+# Viewing Dandisets
 
-## Browse `Dandisets`
+## Browse Dandisets
 
 When you go to the [DANDI Web application](https://dandiarchive.org/), you can click
-on `PUBLIC DANDISET` to have access to all `Dandisets` currently available 
-in the archive and you can sort them by name, identifier, or date of modification.
+on `PUBLIC DANDISET` to access all `Dandisets` currently available 
+in the archive, and you can sort them by name, identifier, or date of modification.
 
 <img
 src="../img/web_browse.png"
 alt="web_browse"
 style="width: 60%; height: auto; display: block; margin-left: auto;  margin-right: auto;"/>
 
-## Search `Dandisets`
-In addition you can search across the `Dandisets` for any text part of the Dandiset metadata record. 
+## Search Dandisets
+In addition, you can search across the `Dandisets` for any text part of the `Dandiset` metadata record. 
 The text may be about contributor names, modalities, or species.  For example,  `"house mouse"` will
 return a subset of all `Dandisets`, while `"mouse house"` will likely not return any. When unquoted each
 word is used as an `OR`.
@@ -32,10 +32,11 @@ alt="web_search_dandiset"
 style="width: 60%; height: auto; display: block; margin-left: auto;  margin-right: auto;"/>
 
 
-## `Dandisets` metadata
+## Dandisets Metadata
 
 The landing page of each `Dandiset` contains important information including 
-metadata provided by the owners such as contact information, description, license, access information and keywords, or simple statistics for `Dandiset` such as size of the `Dandiset` and number of files.
+metadata provided by the owners such as contact information, description, license, access information and keywords, 
+or simple statistics for a `Dandiset` such as size of the `Dandiset` and number of files.
 
 <img
 src="../img/web_dandiset_lp.png"
@@ -48,7 +49,7 @@ If you scroll down, you will also find:
 - Related Resources
 
 While most of the metadata is summarized on the landing page, some additional information can be 
-found by clicking `Metadata` on the right side panel. For Dandiset owners, this button also allows 
+found by clicking `Metadata` on the right-side panel. For `Dandiset` owners, this button also allows 
 adding relevant metadata to populate the landing page.
 
 <img
@@ -56,10 +57,10 @@ src="../img/web_dandiset_metadata.png"
 alt="web_dandiset_metadata"
 style="width: 60%; height: auto; display: block; margin-left: auto;  margin-right: auto;"/>
 
-## File view
+## File View
 
 The right side panel allows you also to access a file browser to navigate the list of folders and files
-in a Dandiset.
+in a `Dandiset`.
 
 <img
 src="../img/web_dandiset_files.png"
@@ -70,11 +71,12 @@ style="width: 60%; height: auto; display: block; margin-left: auto;  margin-righ
 Any file in the `Dandiset` has a download icon
 You can click this icon to download a file to your device where you are browsing
 or right click to get the download URL of the file.
-In addition there is an info icon that leads to full asset metadata. Some files also have a link to external services that can open the file. *Note:* that these services often have size limits and hence are activated only for appropriately sized files.
+In addition, there is an info icon that leads to full asset metadata. Some files also have a link to external 
+services that can open the file. *Note:* that these services often have size limits and hence are activated only for appropriately sized files.
 
 
 ## My Dandisets
-If you are a registered user and you log in, you will also see `My Dandisets` tab:
+If you log in as a registered user, you will also see `My Dandisets` tab:
 
 <img
 src="../img/my_dandiset.png"
@@ -82,4 +84,5 @@ alt="my_dandiset"
 style="width: 7
 0%; height: auto; display: block; margin-left: auto;  margin-right: auto;"/>
 
-By clicking the tab, you can access all the Dandisets you own. For these Dandisets, you can edit and update metadata through the Dandiset actions section, and add or remove other owners or data.
+By clicking the tab, you can access all the `Dandisets` you own. For these `Dandisets`, you can edit and update 
+metadata through the `Dandiset` actions section, and add or remove other owners or data.

--- a/docs/11_view.md
+++ b/docs/11_view.md
@@ -36,7 +36,8 @@ style="width: 60%; height: auto; display: block; margin-left: auto;  margin-righ
 
 The landing page of each `Dandiset` contains important information including 
 metadata provided by the owners such as contact information, description, license, access information and keywords, 
-or simple statistics for a `Dandiset` such as size of the `Dandiset` and number of files.
+ simple statistics for a `Dandiset` such as size of the `Dandiset` and number of files, or
+ a summary of the `Dandiset` including information about species, techniques, and standards.
 
 <img
 src="../img/web_dandiset_lp.png"

--- a/docs/12_download.md
+++ b/docs/12_download.md
@@ -15,7 +15,7 @@ alt="web_dandiset_rsp_download"
 style="width: 30%; height: auto; display: block; margin-left: auto;  margin-right: auto;"/>
 
 
-### Downloading specific files
+### Download specific files
 
 The right-side panel of the `Dandiset` landing page allows you also to access the list of folders and files.
 

--- a/docs/12_download.md
+++ b/docs/12_download.md
@@ -1,21 +1,23 @@
-# Downloading Data
+# Downloading Data and Dandisets
 
+You can download the content of a `Dandiset` using the DANDI Web application (such a specific file) or entire 
+`Dandisets` using the DANDI Python CLI.
 
-## Using the DANDI Web application
+## Using the DANDI Web Application
 
 Once you have the `Dandiset` you are interested in (see more in [the Dandiset View section](./11_view.md)), you can download the content of the `Dandiset`.
-On the landing page of each `Dandiset` you can find `Download` button on the right-hand panel. After clicking the button, you will see the specific command you can use with DANDI Python CLI (as well as the information on how to download the CLI).
+On the landing page of each `Dandiset`, you can find `Download` button on the right-hand panel. After clicking the 
+button, you will see the specific command you can use with DANDI Python CLI (as well as the information on how to download the CLI).
 
-<p float="left">
 <img
 src="../img/web_dandiset_rsp_download.png"
 alt="web_dandiset_rsp_download"
 style="width: 30%; height: auto; display: block; margin-left: auto;  margin-right: auto;"/>
-</p>
+
 
 ### Downloading specific files
 
-The right side panel of the `Dandiset` landing page allows you also to access the list of folders and files.
+The right-side panel of the `Dandiset` landing page allows you also to access the list of folders and files.
 
 <img
 src="../img/web_dandiset_files.png"
@@ -27,23 +29,28 @@ Each file in the `Dandiset` has a download icon next to it, clicking the icon wi
 
 
 
-## Using the Python CLI
+## Using the Python CLI Client
 
-The [DANDI Python client](https://pypi.org/project/dandi/) gives you more option to download entire `Dandisets` and part of the data.
+The [DANDI Python client](https://pypi.org/project/dandi/) gives you more options, such as downloading entire 
+`Dandisets`.
 
-### Download a `Dandiset`
-In order to download entire `Dandiset` you can use the same command as suggested by DANDI web application, e.g.: 
+**Before You Begin**: You need to have Python 3.7+ and install the DANDI Python Client using `pip install dandi`.
+If you have an issue using the Python CLI, see the [Dandi Debugging section](./15_debugging.md).
+
+### Download a Dandiset
+To download an entire `Dandiset`, you can use the same command as suggested by DANDI web application, e.g.: 
 
 `dandi download DANDI:000023`
 
 ### Download data for a specific subject from a Dandiset
-You can download data for the specific subjects. 
-Names of the subjects could be found on DANDI web application or by running a commend with the DANDI CLI: `dandi ls -r DANDI:000023`.
-Once you have the subject id, you can download the data, e.g.:
+You can download data for specific subjects. 
+Names of the subjects can be found on DANDI web application or by running a command with the DANDI CLI: `dandi ls -r 
+DANDI:000023`.
+Once you have the subject ID, you can download the data, e.g.:
 
-`dandi download https://api.dandiarchive.org/api/dandisets/000023/versions/draft/assets/?path=sub-811677083`
+`dandi download https://api.dandiarchive.org/api/dandisets/000023/versions/_draft_/assets/?path=sub-811677083`
 
-You should replace `draft` with a specific version you are interested in (e.g. `0.210914.1900` in the case of this Dandiset).
+You should replace `_draft_` with a specific version you are interested in (e.g. `0.210914.1900` in the case of this `Dandiset`).
 
 You can also use the link from DANDI web application, e.g.:
 
@@ -51,13 +58,11 @@ You can also use the link from DANDI web application, e.g.:
 
 
 ### Download a specific file from a Dandiset 
-Link for the specific file could be found on the DANDI web application, e.g.:
+You can download a specific file from a `Dandiset` when the link for the specific file can be found on the DANDI web 
+application, e.g.:
 
 `dandi download https://api.dandiarchive.org/api/dandisets/000023/versions/0.210914.1900/assets/1a93dc97-327d-4f9c-992d-c2149e7810ae/download/`
 
 
-**Hint:** `dandi download` supports a number of resource identifiers to point to Dandiset, folder, or file.  Providing 
+**Hint:** `dandi download` supports a number of resource identifiers to point to a `Dandiset`, folder, or file.  Providing 
 an incorrect URL (e.g. `dandi download wrongurl`) will provide a list of supported identifiers.
-
-**Remember, that you need to have Python 3.7+ and install the DANDI Python Client using `pip install dandi`.
-In case you have an issue with using Python CLI, please visit [Dandi Debugging section](./15_debugging.md)**.

--- a/docs/13_upload.md
+++ b/docs/13_upload.md
@@ -1,7 +1,8 @@
-# Uploading Data
+# Creating Dandisets and Uploading Data
+
+To create a new `Dandiset` and upload your data, you need to have a DANDI account.
 
 ## Creating an Account on DANDI
-In order to create a new `Dandiset` and upload your data, you need to have a DANDI account.
 
 To create a DANDI account:
 
@@ -12,12 +13,15 @@ You will receive an email acknowledging activation of your account within 24
 hours, after which you can log in to DANDI using GitHub by clicking the login
 button.
 
-## Creating Dandiset and adding the data
+## Creating a Dandiset and Adding Data
 
-You can create a new Dandiset at http://dandiarchive.org . This Dandiset can be fully public or embargoed according to NIH policy.
-When you create a Dandiset, a permanent ID is automatically assigned to it.
-To prevent the production server from being inundated with test Dandisets, we encourage developers to develop 
-against the development server (https://gui-staging.dandiarchive.org/). Please note that the development server
+You can create a new `Dandiset` at [http://dandiarchive.org](http://dandiarchive.org). This `Dandiset` can be fully 
+public or embargoed 
+according to NIH policy.
+When you create a `Dandiset`, a permanent ID is automatically assigned to it.
+To prevent the production server from being inundated with test `Dandisets`, we encourage developers to develop 
+against the development server ([https://gui-staging.dandiarchive.org/](https://gui-staging.dandiarchive.org/)). Note 
+that the development server
 should not be used to stage your data. All data are uploaded as draft and can be adjusted before publishing on
 the production server. The development server is primarily used by users learning to use DANDI or by developers.
 
@@ -26,12 +30,11 @@ two different servers differ slightly.
 
 ### **Setup**
 
-1. If you do not have a DANDI account, [create an account](#create-an-account-on-dandi).
 1. Log in to DANDI and copy your API key. Click on your user initials in the
     top-right corner after logging in. Production (dandiarchive.org) and staging (gui-staging.dandiarchive.org) servers 
       have different API keys and different logins.
 1. Locally:
-    1. Create a Python environment (this is not required, but strongly recommended; e.g. [miniconda](https://conda.
+    1. Create a Python environment. This is not required, but strongly recommended; e.g. [miniconda](https://conda.
           io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#creating-an-environment-with-commands),
          [virtualenv](https://docs.python.org/3/library/venv.html).
     2. Install the DANDI CLI into your Python environment:
@@ -43,10 +46,10 @@ two different servers differ slightly.
 
 ### **Data upload/management workflow**
 
-1. Register a Dandiset to generate an identifier. You will be asked to enter
+1. Register a `Dandiset` to generate an identifier. You will be asked to enter
     basic metadata: a name (title) and description (abstract) for your dataset.
     Click `NEW DANDISET` in the Web application (top right corner) after logging in. 
-    After you provide a name and description, the dataset identifer will be created; 
+    After you provide a name and description, the dataset identifier will be created; 
     we will call this `<dataset_id>`.
 1. NWB format:
     1. Convert your data to NWB 2.1+ in a local folder. Let's call this `<source_folder>`.
@@ -58,11 +61,12 @@ two different servers differ slightly.
 
                 nwbinspector <source_folder> --config dandi
                 
-    3. Thoroughly read through the NWBInspector report and try to address as many issues as possible. **DANDI will prevent validation and upload of any issues
+    3. Thoroughly read the NWBInspector report and try to address as many issues as possible. **DANDI will prevent validation and upload of any issues
     labeled as level 'CRITICAL' or above when using the `--config dandi` option.**
     We recommend regularly running the inspector early in the process to generate the best NWB files possible.
-    Please note that some autodetected violations, such as `check_data_orientation`, may be safely ignored in the event that the data is confirmed to be in the correct form; this can be done using either the `--ignore <name_of_check_to_suppress>` flag or a config file. See [the NWBInspector CLI documentation](https://nwbinspector.readthedocs.io/en/dev/user_guide/command_line_usage.html) for more details and other options, or type `nwbinspector --help`.
-    If the report is too large to efficiently navigate in your console, a report can be saved using
+    Note that some autodetected violations, such as `check_data_orientation`, may be safely ignored in the event 
+       that the data is confirmed to be in the correct form; this can be done using either the `--ignore <name_of_check_to_suppress>` flag or a config file. See [the NWBInspector CLI documentation](https://nwbinspector.readthedocs.io/en/dev/user_guide/command_line_usage.html) for more details and other options, or type `nwbinspector --help`.
+    If the report is too large to efficiently navigate in your console, you can save a report using
 
             nwbinspector <source_folder> --config dandi --report-file-path <report_location>.txt
         
@@ -79,20 +83,20 @@ two different servers differ slightly.
             For upload to the development server, specify that explicitly via `-i` option, e.g.
             `dandi upload -i dandi-staging`.
 
-    6. Add metadata by visiting your Dandiset landing page: 
+    6. Add metadata by visiting your `Dandiset` landing page: 
        `https://dandiarchive.org/dandiset/<dataset_id>/draft` and clicking on the `METADATA` link.
 
-**In case you have an issue with using Python CLI, please visit [Dandi Debugging section](./15_debugging.md)**.
+If you have an issue using the Python CLI, see the [Dandi Debugging section](./15_debugging.md).
 
 ## Storing Access Credentials
 
 By default, the DANDI CLI looks for an API key in the `DANDI_API_KEY`
-environment variable.  To set this on linux or osx, run
+environment variable.  To set this on Linux or macOS, run
 
 ```bash
 export DANDI_API_KEY=personal-key-value
 ```
-(note that there are no spaces around the "=").
+*Note that there are no spaces around the "=".
 
 If this is not set, the CLI will look up the API
 key using the [keyring](https://github.com/jaraco/keyring) library, which

--- a/docs/13_upload.md
+++ b/docs/13_upload.md
@@ -2,7 +2,7 @@
 
 To create a new `Dandiset` and upload your data, you need to have a DANDI account.
 
-## Creating an Account on DANDI
+## Create an Account on DANDI
 
 To create a DANDI account:
 
@@ -13,7 +13,7 @@ You will receive an email acknowledging activation of your account within 24
 hours, after which you can log in to DANDI using GitHub by clicking the login
 button.
 
-## Creating a Dandiset and Adding Data
+## Create a Dandiset and Add Data
 
 You can create a new `Dandiset` at [http://dandiarchive.org](http://dandiarchive.org). This `Dandiset` can be fully 
 public or embargoed 

--- a/docs/14_publish.md
+++ b/docs/14_publish.md
@@ -1,11 +1,15 @@
-# Publish Dandiset
+# Publishing Dandisets
 
-You should first create your `Dandiset` and upload the data, to see more check [the Dandiset Upload section](./14_upload.md).
+Once you create a `Dandiset`, DANDI will automatically create a `draft` version of the `Dandiset` that 
+can be 
+changed as many times as needed. 
 
-Once the `Dandiset` is created, DANDI will automatically create a `draft` version of the `Dandiset` that could be change as many time as needed. Once you are ready to publish your data and to create a unique version of your `Dandiset` you can click `Publish` button (the right panel of the landing page). Note, that the `Publish` button is only active if all the metadata and asset errors are fixed.
+Prior to publishing, you should edit your metadata appropriately
+(e.g. people and funding contributors, protocol information, keywords, related resources in other 
+sources such as publications, code repositories, and other data).
+If you need to change the `Dandiset` or its metadata in the future, you will need to create another version of your 
+`Dandiset`. The content of the specific published version of the `Dandiset` cannot be changed.
 
-It is recommended that you edit your metadata appropriately, **before publishing**, to add different types of information
-(e.g., people and funding contributors, protocol information, keywords, related resources in other 
-sources such as publications, code repositories, other data).
-Remember, that if you need to change the `Dandiset` or its metadata in the future, you will need to create another version of your `Dandiset`. The content of the specific published version of the `Dandiset` can not be changed.
-
+When you are ready to publish your data and to create a unique version of your 
+`Dandiset`, click the `Publish` button (on the right panel of the landing page). Note that the `Publish` 
+button is only active if all the metadata and asset errors are fixed.

--- a/docs/15_debugging.md
+++ b/docs/15_debugging.md
@@ -1,11 +1,9 @@
 # Debugging
 
-## Acquiring Debugging Information
 
-In the event that something goes wrong while using the `dandi` client, the
+If something goes wrong while using the Python CLI client, the
 first place to check for more information so that you can [file a quality bug
-report](https://github.com/dandi/dandi-cli/issues) is the logs.  Every dandi
-command records a copy of its logs in a logfile, the location of which is
+report](https://github.com/dandi/dandi-cli/issues) is the logs.  Every command records a copy of its logs in a logfile, the location of which is
 reported to the user when the command finishes running.  The location of the
 logs varies by platform, e.g.:
 
@@ -15,7 +13,7 @@ logs varies by platform, e.g.:
 Logs are named with a combination of the time at which the `dandi` command
 started running and the process ID of the command.
 
-Recent versions of `dandi` include all possible debugging information in the
+Recent versions of the client include all possible debugging information in the
 logs, but if you're using an older version, only log messages that were printed
 to the user when the command ran are recorded.  As a result, in order to get
 complete debugging information, you may have to rerun the problematic command,
@@ -43,7 +41,7 @@ option:
     dandi download -f debug
 
 More advanced users who are familiar with [the Python
-debugger](https://docs.python.org/3/library/pdb.html) can instruct `dandi` to
+debugger](https://docs.python.org/3/library/pdb.html) can instruct the client to
 automatically open the debugger if any errors occur by supplying the `--pdb`
 option to the command.  Like the `-l`/`--log-level` option, the `--pdb` option
 must be placed between `dandi` and the name of the subcommand.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,7 +19,13 @@ theme:
 nav:
   - Welcome: "index.md"
   - Introduction: "01_introduction.md"
-  - Using DANDI: "10_using_dandi.md"
+  - User Guide:
+    - Using DANDI: "10_using_dandi.md"
+    - Viewing Dandisets: "11_view.md"
+    - Downloading Data and Dandisets: "12_download.md"
+    - Creating Dandisets and Uploading Data: "13_upload.md"
+    - Publishing Dandisets: "14_publish.md"
+    - Debugging: "15_debugging.md"
   - Data Standards: "30_data_standards.md"
   - Developer Guide:
     - Project Structure: "20_project_structure.md"


### PR DESCRIPTION
Fixed items listed in Issue #56 

[ ] - Apply style guidelines to the 5 new subsections added recently to Using Dandi (View, Download, Upload, Publish) and add them to nav TOC under a new umbrella heading "User Guide" (as a parallel to the "Developer Guide" heading).
[ ] -  Make the subheadings parallel with imperative - Download vs Downloading.
[ ] -  In Debugging section, flatten hierarchy by removing Acquiring Debugging Info subsection, only need one heading