### PR TITLE
Refactor Welcome section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,44 +6,45 @@ alt="dandi_banner"
 style="width: 75%; height: auto; display: block; margin-left: auto;  margin-right: auto;"/>
 
 The Web interface to the DANDI archive is located at [https://dandiarchive.org](https://dandiarchive.org).
-This site provides information on how to interact with the archive.
-
-## Where to Communicate:
-- You can ask questions, report bugs, or request features [at our helpdesk](https://github.
-  com/dandi/helpdesk/issues/new/choose).
-- For interacting with the global neuroscience community, post on [https://neurostars.org](https://neurostars.org)
-and use the tag [dandi](https://neurostars.org/tag/dandi).
-- To upload data or to use the DANDI JupyterHub, [register on DANDI using GitHub](https://dandiarchive.org/). 
-  After
-approving your registration, we will invite you to the DANDI Slack workspace. See [here for details on how to register](./10_using_dandi/#create-an-account-on-dandi).
-- Email us: [info@dandiarchive.org](mailto: info@dandiarchive.org)
+This documentation explains how to interact with the archive.
 
 ## How to Use This Documentation
 
-- To start using the archive head over to [Working with DANDI](./10_using_dandi.md).
+If you want to know more about the DANDI project, its goals, and the problems
+it tries to solve, check out the [Introduction](./01_introduction.md).
 
-- If you want to know more about the DANDI project, its goals, and the problems
-it tries to solve, check out our [introduction](./01_introduction.md).
+To start using the archive, head over to [Using DANDI](./10_using_dandi.md) in the User Guide section.
 
-- The DANDI archive stores neurophysiology datasets including electrophysiology,
-optophysiology, and behavioral time-series, and images from immunostaining
-experiments using [NWB](https://www.nwb.org/nwb-neurophysiology/),
-[BIDS](https://bids.neuroimaging.io/), and other BRAIN Initiative standards.
+If are a developer and want to know how the project is organized, check out the [Project Structure](.
+/20_project_structure)
+page in the Developer Guide section.
 
-- Not sure how the project is organized? Check out the [project structure](./20_project_structure)
-page.
 
-## License
+## Where to Get Help
 
-<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+You can communicate with the DANDI team in a variety of ways, depending on your needs:
+
+- You can ask questions, report bugs, or 
+request features [at our helpdesk](https://github.com/dandi/helpdesk/issues/new/choose).
+- For interacting with the global neuroscience community, post on [https://neurostars.org](https://neurostars.org)
+and use the tag [dandi](https://neurostars.org/tag/dandi).
+- You can use the DANDI Slack workspace, which we will invite you to after approving your [registration on 
+  DANDI using GitHub](https://dandiarchive.org/) (this registration is required to upload data or to use the DANDI 
+  JupyterHub). See [here for details on how to 
+  register](./13_upload.md).
+- Email us: [info@dandiarchive.org](mailto: info@dandiarchive.org)
 
 ## Contributing and Feedback
 
 We are looking for people to give us feedback on this documentation. If anything
-is unclear, [open an issue on our repository](https://github.com/dandi/handbook/issues).
-
-You can also get in touch on our Slack channel. You will be invited once you
-register an account on the archive.
+is unclear, [open an issue on our repository](https://github.com/dandi/handbook/issues). You can also get in touch on 
+our Slack channel, which is available to those who have
+registered an account on the archive.
 
 If you want to get started right away and contribute directly to this
-documentation, you can find references and how-to information in the [About section](./100_about_this_doc.md).
+documentation, see the [About This Documentation](.
+/100_about_this_doc.md) section.
+
+## License
+
+<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.


### PR DESCRIPTION
Fixes per issue #63 
- [ ]  Fixed broken/incorrect links
- [ ]  Deleted 3rd bullet in “How to Use this Documentation” (it's just an fyi)
- [ ]  The link to the project structure is for devs, right? Made a general bullet that includes this is for the Developer Guide and also referred to new User Guide section in 2nd bullet
- [ ]  Reordered subsections to be more logical (How to use this Doc first, then how to communicate, Contributing/Feedback, License)