### PR TITLE
ENH: integrate TOC into the navigation bar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,8 @@ theme:
   palette:
     primary: "dark blue"
     accent: "light blue"
+  features:
+    - toc.integrate
 
 # Pages
 nav:


### PR DESCRIPTION
Instead of having a separate TOC on the right , it would just
expand already present navigation on the left, IMHO making
1. a better use of screen real estate, 2. no longer requiring
user to jump with mouse from left to right to navigate