### PR TITLE
Add `search` plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,4 +52,5 @@ markdown_extensions:
 
 # List of plugins
 plugins:
+  - search
   - open-in-new-tab


### PR DESCRIPTION
## Description
- The search bar disappeared after #102, because I added a plugin and thus needed to also explicitly add the built-in `search` plugin (see [built-in search plugin docs](https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/#built-in-search-plugin)).

## Changes
- [x] Add built-in `search` plugin
- [x] Test changes locally, which can also be viewed here: https://kabilar.github.io/handbook/