### PR TITLE
Change the DANDI CLI `Version DOI` to the `Concept DOI`

### DIFF
--- a/docs/10_using_dandi.md
+++ b/docs/10_using_dandi.md
@@ -108,7 +108,7 @@ Note that `Dandihub` is not intended for significant computation, but provides a
 You can add the following statement to the methods section of your manuscript.
 
 > Data and associated metadata were uploaded to the DANDI archive [RRID:SCR_017571] using 
-  the Python command line tool (https://doi.org/10.5281/zenodo.7041535). The data were first 
+  the Python command line tool (https://doi.org/10.5281/zenodo.3692138). The data were first 
   converted into the NWB format (https://doi.org/10.1101/2021.03.13.435173) and  organized 
   into a BIDS-like (https://doi.org/10.1038/sdata.2016.44) structure.
 
@@ -116,4 +116,4 @@ You can refer to DANDI using any of the following options:
 
 * Using an RRID [RRID:SCR_017571](https://scicrunch.org/scicrunch/Resources/record/nlx_144509-1/SCR_017571/resolver). 
 
-* Using the DANDI CLI reference: https://doi.org/10.5281/zenodo.7041535
+* Using the DANDI CLI reference: https://doi.org/10.5281/zenodo.3692138


### PR DESCRIPTION
## Description
- Currently, the `Version DOI` (https://doi.org/10.5281/zenodo.7041535) is listed in the docs and links to version 0.46.2.
- Here I propose using the `Concept DOI` (https://doi.org/10.5281/zenodo.3692138).
- The `Concept DOI` "represents all versions, and will always resolve to the latest one."
- Based on the [Zenodo docs](https://zenodo.org/help/versioning), it is a best practice to use the DOI of a specific version (i.e. the `Version DOI`).  However, I propose that we should use the `Concept DOI`, since we are not updating the docs with each new release of the DANDI CLI and users may be using older versions of the DANDI CLI.