### PR TITLE
Add MagicLink markdown extension for auto-linking http links

### DIFF
--- a/docs/13_upload.md
+++ b/docs/13_upload.md
@@ -15,12 +15,12 @@ button.
 
 ## Create a Dandiset and Add Data
 
-You can create a new Dandiset at [http://dandiarchive.org](http://dandiarchive.org). This Dandiset can be fully 
+You can create a new Dandiset at https://dandiarchive.org. This Dandiset can be fully 
 public or embargoed 
 according to NIH policy.
 When you create a Dandiset, a permanent ID is automatically assigned to it.
 To prevent the production server from being inundated with test Dandisets, we encourage developers to develop 
-against the development server ([https://gui-staging.dandiarchive.org/](https://gui-staging.dandiarchive.org/)). Note 
+against the development server (https://gui-staging.dandiarchive.org/). Note 
 that the development server
 should not be used to stage your data. All data are uploaded as draft and can be adjusted before publishing on
 the production server. The development server is primarily used by users learning to use DANDI or by developers.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ src="./img/dandi-banner.png"
 alt="dandi_banner"
 style="width: 75%; height: auto; display: block; margin-left: auto;  margin-right: auto;"/>
 
-The Web interface to the DANDI archive is located at [https://dandiarchive.org](https://dandiarchive.org).
+The Web interface to the DANDI archive is located at https://dandiarchive.org.
 This documentation explains how to interact with the archive.
 
 ## How to Use This Documentation
@@ -26,7 +26,7 @@ You can communicate with the DANDI team in a variety of ways, depending on your 
 
 - You can ask questions, report bugs, or 
 request features [at our helpdesk](https://github.com/dandi/helpdesk/issues/new/choose).
-- For interacting with the global neuroscience community, post on [https://neurostars.org](https://neurostars.org)
+- For interacting with the global neuroscience community, post on https://neurostars.org
 and use the tag [dandi](https://neurostars.org/tag/dandi).
 - You can use the DANDI Slack workspace, which we will invite you to after approving your [registration on 
   DANDI using GitHub](https://dandiarchive.org/) (this registration is required to upload data or to use the DANDI 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ markdown_extensions:
   - admonition
   - pymdownx.details
   - pymdownx.critic
+  - pymdownx.magiclink
   - toc:
       permalink: True
 


### PR DESCRIPTION
## Changes
- [x] Add MagicLink markdown extension.  See [MagicLink docs](https://facelessuser.github.io/pymdown-extensions/extensions/magiclink/).
- [x] Remove markdown formatted links since these will now auto-link.