### PR TITLE
Pin `mkdocs-material` version to force installing a newer version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-mkdocs-material
+mkdocs-material>=9.5.10
 pymdown-extensions
 mkdocs-open-in-new-tab


### PR DESCRIPTION
## Description
- Currently, the [mkdocs-deploy-gh-pages GitHub Action](https://github.com/mhausenblas/mkdocs-deploy-gh-pages) has an older version of `mkdocs-material` installed since it uses an older base image in the [Dockerfile](https://github.com/mhausenblas/mkdocs-deploy-gh-pages/blob/e55ecab6718b449a90ebd4313f1320f9327f1386/Dockerfile#L1) (i.e. version 9.0.6).
- This has caused a recent merge in this repository to fail in deploying.  See [failed run](https://github.com/dandi/handbook/actions/runs/8011989355/job/21886368888#step:4:93).  See [reference in the GitHub Actions run](https://github.com/dandi/handbook/actions/runs/8011989355/job/21886368888#step:4:7) to `mkdocs-material` version 9.0.6 install.  The recent merge is looking for an asset (i.e. X-Twitter logo) that was added in a newer version of `mkdocs-material`.
- Fix #118 

## Changes
- The changes proposed pin the `mkdocs-material` package to `>=` the latest version (i.e. version 9.5.10) so that the GitHub Actions are forced to install a newer version.