### PR TITLE
State explicitly that our current maximal length of the path in dandiset must no exceed 512

### DIFF
--- a/docs/10_using_dandi.md
+++ b/docs/10_using_dandi.md
@@ -103,6 +103,13 @@ To use the hub, you will need to register for an
 account using the [DANDI Web application](https://dandiarchive.org/). 
 Note that `Dandihub` is not intended for significant computation, but provides a place to introspect Dandisets and to perform some analysis and visualization of data.
 
+## Technical limitations
+
+- **File name/path:** There is a limit of 512 characters for the full path length within a dandiset.
+- **Volume and size:** There is a limit of 5TB per file. We currently
+  accept any size of standardized datasets, as long as you can upload them over
+  an HTTPS connection. However, we ask you contact us if you plan to upload more than 10TB of data.
+
 ## Citing DANDI
 
 You can add the following statement to the methods section of your manuscript.

--- a/docs/about/policies.md
+++ b/docs/about/policies.md
@@ -1,4 +1,4 @@
-# General Policies v1.0.1
+# General Policies v1.1.0
 
 ## Content
 
@@ -19,10 +19,6 @@
   [Neuroimaging Data Model](NIDM), and other [BRAIN Initiative](https://braininitiative.nih.gov/)
   standards. We are working with the community to improve these standards and to
   make DANDI archive FAIR.
-- **File name/path limitations:** There is a limit of 512 characters for the full path length within a dandiset.
-- **Volume and size limitations:** There is a limit of 5TB per file. We currently
-  accept any size of standardized datasets, as long as you can upload them over
-  an HTTPS connection. However, we ask you contact us if you plan to upload more than 10TB of data.
 - **Data quality:** All data are provided “as-is”, and the user shall hold
   DANDI and data providers supplying data to the DANDI Archive free and harmless in
   connection with the use of such data.

--- a/docs/about/policies.md
+++ b/docs/about/policies.md
@@ -19,6 +19,7 @@
   [Neuroimaging Data Model](NIDM), and other [BRAIN Initiative](https://braininitiative.nih.gov/)
   standards. We are working with the community to improve these standards and to
   make DANDI archive FAIR.
+- **File name/path limitations:** There is a limit of 512 characters for the full path length within a dandiset.
 - **Volume and size limitations:** There is a limit of 5TB per file. We currently
   accept any size of standardized datasets, as long as you can upload them over
   an HTTPS connection. However, we ask you contact us if you plan to upload more than 10TB of data.


### PR DESCRIPTION

ATM, if my check is right -- maximal length we can encounter is only 192, so we are quite ok

	dandi@drogon:/mnt/backup/dandi/dandisets$ pwd
	/mnt/backup/dandi/dandisets

	dandi@drogon:/mnt/backup/dandi/dandisets$ declare m=0;for ds in 00*; do git -C $ds ls-tree -r --name-only HEAD; done | awk '{ if (length($0) > max) max = length($0) } END { print max }'
	192

When user manages to get over -- server 500s. Filed 
- https://github.com/dandi/dandi-archive/issues/1889