### PR TITLE
Rename the `About This Doc` page to `Contributing Documentation`

### DIFF
--- a/docs/100_contribute_docs.md
+++ b/docs/100_contribute_docs.md
@@ -1,4 +1,4 @@
-# About This Documentation
+# Contributing Documentation
 
 This documentation is a work in progress and we welcome all input: if something
 is missing or unclear, let us know by [opening an issue on our helpdesk](https://github.com/dandi/helpdesk/issues/new/choose).

--- a/docs/100_contribute_docs.md
+++ b/docs/100_contribute_docs.md
@@ -1,4 +1,4 @@
-# Contributing Documentation
+# Contributing to this Handbook
 
 This documentation is a work in progress and we welcome all input: if something
 is missing or unclear, let us know by [opening an issue on our helpdesk](https://github.com/dandi/helpdesk/issues/new/choose).

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ registered an account on the archive.
 
 If you want to get started right away and contribute directly to this
 documentation, see the [About This Documentation](.
-/100_about_this_doc.md) section.
+/100_contribute_docs.md) section.
 
 ## License
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,11 +37,11 @@ nav:
     - Notes: "40_development.md"
     - REST API Swagger: https://api.dandiarchive.org/swagger
     - REST API Redoc: https://api.dandiarchive.org/redoc
+    - Contributing Documentation: "100_contribute_docs.md"
   - DANDI Hub: "50_hub.md"
   - Terms and Policies:
       - Terms: "about/terms.md"
       - Policies: "about/policies.md"
-  - About This Doc: "100_about_this_doc.md"
 
 # List of extensions
 markdown_extensions:


### PR DESCRIPTION
In order to better describe the `About This Doc` page and inspired by the [Napari docs](https://napari.org/stable/developers/documentation/index.html), I propose:
- [x] Rename the `About This Doc` page to `Contributing Documentation`
- [x] Move the `Contributing Documentation` page to within the `Developer Guide` section