### PR TITLE
Fix `Support` page heading

### DIFF
--- a/docs/support.md
+++ b/docs/support.md
@@ -1,4 +1,4 @@
-## Support
+# Support
 
 **For questions and support, we recommend using [GitHub Discussions](https://github.com/dandi/helpdesk/discussions/new?category=q-a)** 🙏
 


### PR DESCRIPTION
Currently it shows up as:

<img width="720" height="208" alt="image" src="https://github.com/user-attachments/assets/32ada486-dac9-4983-995f-ade89ec33f1a" />