### PR TITLE
Update spacing to fix list rendering

### DIFF
--- a/docs/user-guide-sharing/converting-data/index.md
+++ b/docs/user-guide-sharing/converting-data/index.md
@@ -6,6 +6,7 @@ Most of the data on DANDI is in Neurodata Without Borders (NWB), a data standard
 See [Converting data to NWB](./nwb/index.md) for guidance in how to convert your data to NWB and publish on DANDI.
 
 DANDI also supports the [Brain Imaging Data Structure (BIDS)](https://bids.neuroimaging.io/). For more information, see:
+
 - [Getting Started with BIDS](https://bids.neuroimaging.io/getting_started/index.html)
 - [BIDS converters](https://bids.neuroimaging.io/tools/converters.html) for conversion of raw data to a BIDS dataset
 - [BIDS specification](https://bids-specification.readthedocs.io)


### PR DESCRIPTION
This [page](https://docs.dandiarchive.org/user-guide-sharing/converting-data/) currently shows up incorrectly:

<img width="1065" height="332" alt="image" src="https://github.com/user-attachments/assets/98956411-2ff4-4beb-a005-e80c7e41deda" />