### PR TITLE
Add Netlify PR preview deployments

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,10 @@
+# Netlify configuration for PR preview deployments.
+# Production site remains on GitHub Pages (docs.dandiarchive.org).
+# Netlify is used ONLY for PR previews — do NOT configure a custom domain here.
+
+[build]
+  command = "git submodule update --init && pip install -r requirements.txt && mkdocs build"
+  publish = "site"
+
+[build.environment]
+  PYTHON_VERSION = "3.11"


### PR DESCRIPTION
## Summary

Add Netlify configuration for automatic PR preview deployments, resolving the long-standing request in #119.

- Production deployment stays on **GitHub Pages** (`docs.dandiarchive.org`) — no changes there
- Netlify is used **only for PR previews** — every PR gets an automatic preview link posted as a comment
- Single file addition: `netlify.toml`

## Setup required (one-time, Netlify dashboard)

Connect Netlify **before merging** so this PR itself serves as the test:

1. Go to [app.netlify.com](https://app.netlify.com/) and sign in with GitHub
2. Click **"Add new site"** → **"Import an existing project"** → select **GitHub**
3. Authorize the Netlify GitHub App for the `dandi` org (if not already done)
4. Select the **`dandi/dandi-docs`** repository
5. Netlify will auto-detect `netlify.toml` from the PR branch — click **"Deploy site"**
6. **Important**: Do **NOT** add a custom domain (`docs.dandiarchive.org`) in Netlify — that stays on GitHub Pages
7. Optionally rename the Netlify site to something recognizable (e.g., `dandi-docs`) in **Site configuration** → **Site details** → **Change site name**

Netlify will immediately pick up this open PR and post a preview link, confirming everything works before merge.

After this, every future PR will automatically get:
- A Netlify build triggered on open/push
- A deploy preview link posted as a PR comment (e.g., `https://deploy-preview-42--dandi-docs.netlify.app`)
- A GitHub status check showing build pass/fail

## Test plan

- [x] `netlify.toml` build command works: `pip install -r requirements.txt && mkdocs build`
- [ ] Connect repo on Netlify, verify it builds this PR and posts a preview link
- [ ] Verify the preview renders correctly

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)
