### PR TITLE
Rename staging references to sandbox in developer guide

### DIFF
--- a/docs/developer-guide/creating-dandi-instance/dandi-infrastructure.md
+++ b/docs/developer-guide/creating-dandi-instance/dandi-infrastructure.md
@@ -196,7 +196,7 @@ and [staging_pipeline.tf](https://github.com/dandi/dandi-infrastructure/blob/mas
 
 Setting up sandbox will require unique AWS Route 53 Domains, as well a different Heroku app with different compute.
 
-**Note -- ensure you review your `web/netlify.toml` file in DANDI Archive -- this will define different environment variables that correspond with staging vs. production**
+**Note -- ensure you review your `web/netlify.toml` file in DANDI Archive -- this will define different environment variables that correspond with sandbox vs. production**
 
 ### Email Setup
 

--- a/docs/developer-guide/creating-dandi-instance/initialize-vendors.md
+++ b/docs/developer-guide/creating-dandi-instance/initialize-vendors.md
@@ -6,7 +6,7 @@ The DANDI ecosystem relies on vendor services to operate.  So first you will nee
 - **AWS**: Provides storage buckets (S3), as well as domain management (Route53), for resources across the DANDI ecosystem. As well as the services (EC2, Kubernetes, etc.) for deploying the JupyterHub.
 - **GitHub**: Serves as the authentication provider for accounts across the DANDI ecosystem.
 - **Terraform Cloud**: Manages provisioned resources across cloud vendors in a version-controlled manner. 
-- **Netlify**: Deploys production frontend build, as well as staging previews to assist with frontend development.
+- **Netlify**: Deploys production frontend build, as well as sandbox previews to assist with frontend development.
 - **Sentry**: Provides observability and monitoring for API events.
 
 Some services are not yet integrated within the main infrastructure:

--- a/docs/developer-guide/developer-notes.md
+++ b/docs/developer-guide/developer-notes.md
@@ -104,7 +104,7 @@ To access Sentry, login to https://dandiarchive.sentry.io .
 
 ### Heroku & Papertrail
 
-The `dandi-api` and `dandi-api-sandbox` apps have the Papertrail add-on configured to capture logs.
+The `dandi-api` and `dandi-api-staging` apps have the Papertrail add-on configured to capture logs.
 To access Papertrail, log in to the [Heroku dashboard](https://dashboard.heroku.com), proceed to the corresponding app and click on the "Papertrail" add-on.
 
 A cronjob on the `drogon` server backs up Papertrail logs as .csv files hourly at `/mnt/backup/dandi/papertrail-logs/{app}`.

--- a/docs/developer-guide/developer-notes.md
+++ b/docs/developer-guide/developer-notes.md
@@ -104,7 +104,7 @@ To access Sentry, login to https://dandiarchive.sentry.io .
 
 ### Heroku & Papertrail
 
-The `dandi-api` and `dandi-api-staging` apps have the Papertrail add-on configured to capture logs.
+The `dandi-api` and `dandi-api-sandbox` apps have the Papertrail add-on configured to capture logs.
 To access Papertrail, log in to the [Heroku dashboard](https://dashboard.heroku.com), proceed to the corresponding app and click on the "Papertrail" add-on.
 
 A cronjob on the `drogon` server backs up Papertrail logs as .csv files hourly at `/mnt/backup/dandi/papertrail-logs/{app}`.
@@ -120,7 +120,7 @@ Logs for many of the repositories are archived on `drogon` server at `/mnt/backu
 All code repositories are hosted on GitHub. The easiest way to contribute is to
 gain push access to the repositories by talking to @waxlamp; this way, you can
 create pull requests based on branches within the origin repositories, which in
-turn allows for Netlify deploy previews and Heroku staging previews to be built.
+turn allows for Netlify deploy previews and Heroku sandbox previews to be built.
 
 However, this is not strictly required. You can contribute using the standard
 fork-and-pull-request model, but under this workflow we will lose the benefit of


### PR DESCRIPTION
## Summary
- Replace remaining `staging` references in the developer guide with `sandbox` to match the terminology used elsewhere in the docs and in the deployment (e.g. `dandi-api-sandbox`).
- Touches three pages: `dandi-infrastructure.md`, `initialize-vendors.md`, and `developer-notes.md`. Four total text edits, no structural changes.

## Test plan
- [ ] `mkdocs build` succeeds
- [ ] Spot-check the three pages render correctly in preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)