### PR TITLE
doc: remove mentioning of WebDAV as potentially we will sunset that service

### DIFF
--- a/docs/developer-guide/integrate-external-services.md
+++ b/docs/developer-guide/integrate-external-services.md
@@ -107,18 +107,7 @@ asset = dandiset.get_asset_by_path("path/to/file.nwb")
 asset.download("local_file.nwb")
 ```
 
-### 3. WebDAV Integration
-
-DANDI provides a [WebDAV](https://en.wikipedia.org/wiki/WebDAV) service at https://webdav.dandiarchive.org/ that allows external services to access DANDI data using standard WebDAV clients:
-
-```python
-import requests
-
-# Access a file via WebDAV
-response = requests.get("https://webdav.dandiarchive.org/dandisets/000123/draft/path/to/file.nwb")
-```
-
-### 4. Custom Visualization Services
+### 3. Custom Visualization Services
 
 To integrate a custom visualization service with DANDI:
 

--- a/docs/user-guide-using/accessing-data/downloading.md
+++ b/docs/user-guide-using/accessing-data/downloading.md
@@ -110,24 +110,6 @@ Learn more about DataLad from its handbook at <https://handbook.datalad.org/>.
 
 **Developers' note:** DataLad datasets are created using the [dandi/backups2datalad](https://github.com/dandi/backups2datalad/) tool which is also available for use by the community to similarly maintain mirrors of independent DANDI deployments as DataLad datasets.
 
-## Using WebDAV
-
-DANDI provides a [WebDAV](https://en.wikipedia.org/wiki/WebDAV) service at https://webdav.dandiarchive.org/ for accessing the data in the DANDI archive.
-You can use any WebDAV client or even a web browser to access the data - any Dandiset, any version, any file or collection of files, and navigate inside Zarr assets (including their versions).
-
-You can use any web download tool to download the data from the DANDI archive, e.g.
-
-````commandline
-wget -r -np -nH --cut-dirs=3 https://webdav.dandiarchive.org/dandisets/000027/releases/0.210831.2033/
-````
-
-for a download of a specific release `0.210831.2033` of the `000027` dandiset.
-
-**Note:** The WebDAV service does not directly serve any file contents; it instead relies on redirects to AWS S3 storage where the contents are stored.
-You might need to configure your WebDAV client to follow redirects; e.g., for the [davfs2](https://savannah.nongnu.org/projects/davfs2) WebDAV client, set `follow_redirect` to `1` in `/etc/davfs2/davfs2.conf`.
-
-**Developers' note:** The WebDAV service's code is available at https://github.com/dandi/dandidav/ and can also be used for independent DANDI deployments.
-
 
 ## Using S3 Directly
 

--- a/docs/user-guide-using/accessing-data/index.md
+++ b/docs/user-guide-using/accessing-data/index.md
@@ -9,9 +9,8 @@ DANDI offers several methods for accessing data, each suited to different use ca
 1. **Web Interface**: Browse and download individual files directly from the DANDI web application.
 2. **DANDI CLI**: Command-line tool for downloading entire Dandisets or specific files.
 3. **DataLad**: Access Dandisets as Git repositories with DataLad for version control and reproducibility.
-4. **WebDAV**: Access DANDI data using standard WebDAV clients.
-5. **DANDI Hub**: Analyze data directly in the cloud using Jupyter notebooks.
-6. **Programmatic Access**: Access data programmatically using the DANDI API through Python or other languages.
+4. **DANDI Hub**: Analyze data directly in the cloud using Jupyter notebooks.
+5. **Programmatic Access**: Access data programmatically using the DANDI API through Python or other languages.
 
 ## Choosing the Right Access Method
 
@@ -20,7 +19,7 @@ The best method for accessing data depends on your specific needs:
 - **For browsing and exploring data**: Use the [Web Interface](./downloading.md#using-the-dandi-web-application).
 - **For downloading entire Dandisets**: Use the [DANDI CLI](./downloading.md#using-the-python-cli-client).
 - **For version control and reproducibility**: Use [DataLad](./downloading.md#using-datalad).
-- **For integration with existing tools**: Use [WebDAV](./downloading.md#using-webdav), [DANDI Python and Command-line Client](./downloading.md#using-the-python-cli-client), or [DANDI API](./external-services.md#custom-integrations) depending on the tool language/interfaces.
+- **For integration with existing tools**: Use [DANDI Python and Command-line Client](./downloading.md#using-the-python-cli-client), or [DANDI API](./external-services.md#custom-integrations) depending on the tool language/interfaces.
 - **For cloud-based analysis**: Use [DANDI Hub](../dandi-hub.md).
 - **For programmatic access**: Use the [DANDI Python Client](https://dandi.readthedocs.io/) for Python or the [DANDI API](./external-services.md#custom-integrations) for other languages.
 
@@ -37,7 +36,7 @@ When accessing data from DANDI, consider the following:
 
 Explore the following pages for detailed information on each access method:
 
-- [Downloading Data](./downloading.md): Learn how to download data using the web interface, DANDI CLI, DataLad, or WebDAV.
+- [Downloading Data](./downloading.md): Learn how to download data using the web interface, DANDI CLI, DataLad, or directly from S3.
 - [Streaming Data](./streaming.md): Learn how to stream data without downloading entire files.
 - [External Services](./external-services.md): Learn about external services that can be used to access and analyze DANDI data.
 - [DANDI Hub](../dandi-hub.md): Learn how to use DANDI Hub for cloud-based analysis.


### PR DESCRIPTION
Per our brief conversion, it is unclear if anyone uses this service productively, but it could be potentially brining more load to the server. So, for now lets not promote it at least

edit: I did bring webdav service down and closed some related PRs against dandi-archive